### PR TITLE
#8 Make some refs private so they are not a dependency of the Nuget package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,9 @@
 
   <!-- Activate fxcop -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" !$(MSBuildProjectName.EndsWith('.Tests')) ">
     <CodeAnalysisRuleSet>../../Standard.ruleset</CodeAnalysisRuleSet>
@@ -32,7 +34,9 @@
   <!-- Activate stylecop -->
   <ItemGroup>
     <AdditionalFiles Include="../../stylecop.json" Link="stylecop.json" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <!-- Define specific rules for test projects -->


### PR DESCRIPTION
I've made these private so they do not automatically get installed when installing this analyzer into a project.